### PR TITLE
bring mtimes to SP2013, cache files, temp. disable broken fetching of permission

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -162,6 +162,10 @@ class Client {
 	public function fetchFolder($relativeServerPath, array $properties = null) {
 		$this->ensureConnection();
 		$folder = $this->context->getWeb()->getFolderByServerRelativeUrl($relativeServerPath);
+		if($this->isSP2013) {
+			$allFields = $folder->getListItemAllFields();
+			$this->context->load($allFields);
+		}
 		$this->loadAndExecute($folder, $properties);
 
 		if($this->isSP2013 === null
@@ -172,6 +176,8 @@ class Client {
 				\OC::$server->getLogger()->debug('SP 2013 detected against {path}',
 					['app' => 'sharepoint', 'path' => $relativeServerPath]);
 			}
+			$allFields = $folder->getListItemAllFields();
+			$this->loadAndExecute($allFields);
 		}
 
 		return $folder;

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -366,7 +366,7 @@ class Client {
 		$fileCollection = $folder->getFiles();
 
 		$this->context->load($folderCollection, self::DEFAULT_PROPERTIES);
-		$this->context->load($fileCollection, self::DEFAULT_PROPERTIES);
+		$this->context->load($fileCollection, array_merge(self::DEFAULT_PROPERTIES, [Storage::SP_PROPERTY_URL]));
 		$this->context->executeQuery();
 
 		$collections = ['folders' => $folderCollection, 'files' => $fileCollection];

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -443,6 +443,26 @@ class Client {
 		return $lists->getData();
 	}
 
+	public function getDocumentLibrary(string $documentLibrary):SPList {
+		static $list = null;
+		if($list instanceof SPList) {
+			return $list;
+		}
+
+		$this->ensureConnection();
+		$title = substr($documentLibrary, strrpos($documentLibrary, '/') + 1);
+		$lists = $this->context->getWeb()->getLists()->getByTitle($title);
+		$this->loadAndExecute($lists);
+		if($lists instanceof SPList) {
+			$list = $lists;
+			return $list;
+		}
+		if($lists->getCount() === 0) {
+			throw new NotFoundException('No list found');
+		}
+		throw new NotFoundException('Too many lists found');
+	}
+
 	/**
 	 * shortcut for querying a provided object from SP
 	 *

--- a/lib/Storage/Storage.php
+++ b/lib/Storage/Storage.php
@@ -207,6 +207,10 @@ class Storage extends Common {
 
 		$size = $file->getProperty(self::SP_PROPERTY_SIZE) ?: FileInfo::SPACE_UNKNOWN;
 		$mtimeValue = (string)$file->getProperty(self::SP_PROPERTY_MTIME);
+		if($mtimeValue === '') {
+			// if sp2013 ListItemAllFields are fetched automatically
+			$mtimeValue = $file->getListItemAllFields()->getProperty('Modified');
+		}
 		$name = (string)$file->getProperty(self::SP_PROPERTY_NAME);
 
 		if($mtimeValue === '') {

--- a/lib/Storage/Storage.php
+++ b/lib/Storage/Storage.php
@@ -616,6 +616,9 @@ class Storage extends Common {
 	 * @throws NotFoundException
 	 */
 	private function getUserPermissions($serverUrl) {
+		// temporarily, cf. https://github.com/vgrem/phpSPO/issues/93#issuecomment-489024363
+		throw new NotFoundException('Could not retrieve permissions');
+
 		$item = $this->getFileOrFolder($serverUrl);
 		$entry = $this->fileCache->get($serverUrl);
 		if(isset($entry['permissions'])) {

--- a/lib/Storage/Storage.php
+++ b/lib/Storage/Storage.php
@@ -593,7 +593,7 @@ class Storage extends Common {
 					/** @var  File|Folder $item */
 					$url = $item->getProperty(self::SP_PROPERTY_URL);
 					if(is_null($url)) {
-						// at least on SP13 $url is null, although it should not
+						// at least on SP13 requesting self::SP_PROPERTY_URL against folders causes an exception
 						continue;
 					}
 					$itemEntry = $this->fileCache->get($url);

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -32,6 +32,7 @@ use Office365\PHP\Client\SharePoint\File;
 use Office365\PHP\Client\SharePoint\FileCollection;
 use Office365\PHP\Client\SharePoint\Folder;
 use Office365\PHP\Client\SharePoint\FolderCollection;
+use Office365\PHP\Client\SharePoint\ListItem;
 use Office365\PHP\Client\SharePoint\Web;
 use Test\TestCase;
 
@@ -101,7 +102,12 @@ class SharePointClientTest extends TestCase {
 			->method('getAuthContext')
 			->willReturn($this->createMock(AuthenticationContext::class));
 
+		$listItemAllFieldsMock = $this->createMock(ListItem::class);
+
 		$folderMock = $this->createMock(Folder::class);
+		$folderMock->expects($this->any())
+			->method('getListItemAllFields')
+			->willReturn($listItemAllFieldsMock);
 
 		$webMock = $this->createMock(Web::class);
 		$webMock->expects($this->never())
@@ -115,13 +121,12 @@ class SharePointClientTest extends TestCase {
 		$clientContextMock->expects($this->once())
 			->method('getWeb')
 			->willReturn($webMock);
-		$clientContextMock->expects($this->once())
-			->method('load')
-			->withConsecutive([$folderMock, $properties]);
-		$clientContextMock->expects($this->once())
+		$clientContextMock->expects($this->atLeastOnce())
+			->method('load');
+		$clientContextMock->expects($this->atLeastOnce())
 			->method('executeQuery');
 
-		$this->contextsFactory->expects($this->once())
+		$this->contextsFactory->expects($this->atLeastOnce())
 			->method('getClientContext')
 			->willReturn($clientContextMock);
 
@@ -312,10 +317,15 @@ class SharePointClientTest extends TestCase {
 			$itemClass = File::class;
 		}
 
+		$listItemAllFieldsMock = $this->createMock(ListItem::class);
+
 		$itemMock = $this->createMock($itemClass);
 		$itemMock->expects($this->once())
 			->method($spRenameMethod)
 			->with($spRenameParameter);
+		$itemMock->expects($this->any())
+			->method('getListItemAllFields')
+			->willReturn($listItemAllFieldsMock);
 
 		$this->contextsFactory->expects($this->once())
 			->method('getAuthContext')
@@ -336,7 +346,7 @@ class SharePointClientTest extends TestCase {
 			->method('getClientContext')
 			->willReturn($clientContextMock);
 
-		$clientContextMock->expects($this->exactly(2))
+		$clientContextMock->expects($this->atLeast(2))
 			->method('executeQuery');
 
 		$this->client->rename($path, $newPath);


### PR DESCRIPTION
When looking how to improve performance again, by accident I found possibilities to fetch mtimes on SP 2013 via others means, and also for document libraries.

Runtime caching for file instances read from folders was reintroduced.

Fetching permissions was disabled as it was not working anyhow. This needs to be handled upstream (and I have a quick and dirty PoC for later).
