### PR TITLE
fix `occ` not working due to this bug

### DIFF
--- a/lib/Backend/Provider.php
+++ b/lib/Backend/Provider.php
@@ -46,5 +46,5 @@ class Provider implements IBackendProvider {
 			new Password($this->lFactory->get('files_external'))
 		);
 		return [ $backend ];
-	}
+	};
 }


### PR DESCRIPTION
Please read more here; https://help.nextcloud.com/t/sharepoint-app-gives-white-screen-after-install/44642

This fix works. Without it the login screen goes WSOD and `occ` stops working.

Tested on Nextcloud 17.0.2

Please review.