### PR TITLE
Fix content-length header casing

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -217,7 +217,7 @@ class Client {
 		$request->addCustomHeader('X-HTTP-Method','PUT'); // yes, PUT
 		$this->context->ensureFormDigest($request);
 		$request->StreamHandle = $fp;
-		$request->addCustomHeader("content-length", filesize($localPath));
+		$request->addCustomHeader("Content-Length", filesize($localPath));
 
 		return false !== $this->context->executeQueryDirect($request);
 	}


### PR DESCRIPTION
Change header "content-length" to "Content-Length" (change the case). 
Without this change the "$this->context->executeQueryDirect" add a second "Content-Length" witch came in the header with a 0 value. 
This make the file update failed.