### PR TITLE
Log exception that might happen during token auth for easier debugging

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -486,6 +486,13 @@ class Client {
 			$this->authContext = $this->contextsFactory->getTokenAuthContext($this->sharePointUrl);
 			$this->authContext->acquireTokenForUser($this->credentials['user'], $this->credentials['password']);
 		} catch (Exception $e) {
+			\OC::$server->getLogger()->logException($e,
+				[
+					'message' => 'Failed to acquire token for user, fall back to NTLM auth',
+					'app' => 'sharepoint',
+					'level' => ILogger::DEBUG
+				]
+			);
 			// fall back to NTLM
 			$this->authContext = $this->contextsFactory->getCredentialsAuthContext($this->credentials['user'], $this->credentials['password']);
 			$this->authContext->AuthType = CURLAUTH_NTLM;


### PR DESCRIPTION
This should make debugging setup issues a bit easier as when the token auth fails and it falls back to NTLM auth there is nothing logged as the php-spo library just fails silently on a 401 response when using `CURLAUTH_NTLM`