### PR TITLE
[stable21] use supported mariadb image for tests

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -84,7 +84,7 @@ jobs:
 
     services:
       mysql:
-        image: mariadb
+        image: mariadb:10.5
         ports:
           - 4444:3306/tcp
         env:


### PR DESCRIPTION
backport of https://github.com/nextcloud/sharepoint/pull/119