### PR TITLE
[stable24] exclude .php-cs-fixer.dist.php from packaging

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -8,6 +8,7 @@ krankerl.toml
 Makefile
 .nextcloudignore
 phpunit.*
+.php-cs-fixer.dist.php
 .php_cs.dist
 screenshots
 .scrutinizer.yml


### PR DESCRIPTION
backport of https://github.com/nextcloud/sharepoint/pull/163