### PR TITLE
SP files are case insensitive. Lowercasing the url may save requests.

### DIFF
--- a/lib/Storage/Storage.php
+++ b/lib/Storage/Storage.php
@@ -695,7 +695,7 @@ class Storage extends Common {
 	 * @return string
 	 */
 	private function formatPath($path) {
-		$path = trim($path, '/');
+		$path = mb_strtolower(trim($path, '/'));
 		$rootFolder = $this->spClient->getDocumentLibrariesRootFolder($this->documentLibrary);
 		$serverUrl = $rootFolder->getProperty(self::SP_PROPERTY_URL);
 		if ($path !== '') {

--- a/tests/Unit/StorageTest.php
+++ b/tests/Unit/StorageTest.php
@@ -150,7 +150,7 @@ class StorageTest extends TestCase {
 
 		$serverPath = $this->documentLibraryTitle;
 		if (trim($path, '/') !== '') {
-			$serverPath .= '/' . trim($path, '/');
+			$serverPath .= '/' . mb_strtolower(trim($path, '/'));
 		}
 
 		$this->client->expects($this->any())
@@ -224,7 +224,7 @@ class StorageTest extends TestCase {
 
 		$serverPath = '/' . $this->documentLibraryTitle;
 		if (trim($path, '/') !== '') {
-			$serverPath .= '/' . trim($path, '/');
+			$serverPath .= '/' . mb_strtolower(trim($path, '/'));
 		}
 
 		$this->prepareMocksForGetDocLibrary();
@@ -292,7 +292,7 @@ class StorageTest extends TestCase {
 	 */
 	public function testMkDir($successful) {
 		$dirName = '/Parentfolder/NewDirectory';
-		$serverPath = '/' . $this->documentLibraryTitle . $dirName;
+		$serverPath = '/' . $this->documentLibraryTitle . mb_strtolower($dirName);
 
 		[, $folderMock] = $this->prepareMocksForGetDocLibrary();
 
@@ -326,7 +326,7 @@ class StorageTest extends TestCase {
 	 */
 	public function testRmDir($successful) {
 		$dirName = '/Parentfolder/TargetDirectory';
-		$serverPath = '/' . $this->documentLibraryTitle . $dirName;
+		$serverPath = '/' . $this->documentLibraryTitle . mb_strtolower($dirName);
 
 		[, $folderMock] = $this->prepareMocksForGetDocLibrary();
 


### PR DESCRIPTION
- this reduces per page requests from 9 to up to three for Rich Workspaces, which are testing for three variations of readme.md