### PR TITLE
build step updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,11 @@
 {
+	"autoload": {
+		"psr-4": {
+			"OCA\\SharePoint\\": "lib/"
+		}
+	},
 	"config": {
+		"autoloader-suffix": "SharePoint",
 		"platform": {
 			"php": "8.0"
 		}

--- a/composer/autoload.php
+++ b/composer/autoload.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';

--- a/krankerl.toml
+++ b/krankerl.toml
@@ -2,5 +2,4 @@
 
 before_cmds = [
         "composer install --no-dev",
-        "composer remove --update-no-dev cweagans/composer-patches"
 ]

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -23,8 +23,6 @@
 
 namespace OCA\SharePoint\AppInfo;
 
-require_once __DIR__ . '/../../vendor/autoload.php';
-
 use OCA\SharePoint\Listener\ExternalStoragesRegistrationListener;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;


### PR DESCRIPTION
- require autoload from composer/autoload.php instead of Application
- remove unneeded build command
- cannot make autoloader optimized or authoritative for phpSPO is incompatible due to unorthodox dir names (leading backslashes)